### PR TITLE
Bug Fix and added functionality to stopMonitoring the clipboard on Android

### DIFF
--- a/android/src/main/kotlin/com/example/clipboard_monitor/ClipboardMonitorPlugin.kt
+++ b/android/src/main/kotlin/com/example/clipboard_monitor/ClipboardMonitorPlugin.kt
@@ -1,65 +1,66 @@
 package com.example.clipboard_monitor
 
 import android.content.ClipboardManager
+import android.content.Context
 import androidx.annotation.NonNull
-
 import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
-import android.content.Context
-import io.flutter.plugin.common.BinaryMessenger
-
-
 
 
 /** ClipboardMonitorPlugin */
-class ClipboardMonitorPlugin: FlutterPlugin, MethodCallHandler {
+class ClipboardMonitorPlugin : FlutterPlugin, MethodCallHandler {
 
 
-  /// The MethodChannel that will the communication between Flutter and native Android
-  ///
-  /// This local reference serves to register the plugin with the Flutter Engine and unregister it
-  /// when the Flutter Engine is detached from the Activity
-  private lateinit var channel : MethodChannel
-  private lateinit var mContext : Context
+    /// The MethodChannel that will the communication between Flutter and native Android
+    ///
+    /// This local reference serves to register the plugin with the Flutter Engine and unregister it
+    /// when the Flutter Engine is detached from the Activity
+    private lateinit var channel: MethodChannel
+    private lateinit var mContext: Context
+    private lateinit var clipboard: ClipboardManager
+    private lateinit var clipBoardCallback: () -> Unit
 
-  private val CHANNEL_NAME = "clipboard_monitor"
+    private val CHANNEL_NAME = "clipboard_monitor"
 
-  private fun setupChannel(messenger: BinaryMessenger, context: Context) {
-    channel = MethodChannel(messenger, CHANNEL_NAME)
-    mContext = context
-    channel.setMethodCallHandler(this)
-  }
-
-  override fun onAttachedToEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
-    setupChannel(binding.binaryMessenger, binding.applicationContext);
-  }
-
-  override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
-    if (call.method == "monitorClipboard") {
-
-      val clipboard = mContext.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-
-      clipboard.addPrimaryClipChangedListener {
-        val clip = clipboard.primaryClip
-        if (clip?.itemCount == 1) {
-          val text = clip.getItemAt(0).text
-          if (text.isNotEmpty()) {
-            channel.invokeMethod("cliptext", text)
-          }
-        }
-      }
-
-      result.success(true)
-
-    } else {
-      result.notImplemented()
+    private fun setupChannel(messenger: BinaryMessenger, context: Context) {
+        channel = MethodChannel(messenger, CHANNEL_NAME)
+        mContext = context
+        channel.setMethodCallHandler(this)
     }
-  }
 
-  override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
-    channel.setMethodCallHandler(null)
-  }
+    override fun onAttachedToEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
+        setupChannel(binding.binaryMessenger, binding.applicationContext);
+        clipboard = mContext.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        // store reference to callback so it can be removed later
+        clipBoardCallback = {
+            val text = clipboard.primaryClip?.getItemAt(0)?.text
+            if (!text.isNullOrBlank()) {
+                channel.invokeMethod("cliptext", text.toString())
+            }
+        }
+    }
+
+    override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
+      when (call.method) {
+          "monitorClipboard" -> {
+            clipboard.addPrimaryClipChangedListener(clipBoardCallback)
+            result.success(true)
+          }
+          "stopMonitoringClipboard" -> {
+            clipboard.removePrimaryClipChangedListener(clipBoardCallback)
+            result.success(true)
+          }
+          else -> {
+            result.notImplemented()
+          }
+      }
+    }
+
+    override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
+        channel.setMethodCallHandler(null)
+    }
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:4.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jun 23 08:50:38 CEST 2017
+#Sun Jan 10 19:11:36 COT 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip

--- a/lib/clipboard_monitor.dart
+++ b/lib/clipboard_monitor.dart
@@ -40,6 +40,14 @@ class ClipboardMonitor {
     }
   }
 
+  static void unregisterAllCallbacks() {
+    _callbacks.clear();
+
+    if (Platform.isAndroid) {
+      _stopMonitoring();
+    }
+  }
+
   static Future<void> _handleMethodCall(MethodCall call) async {
     final args = call.arguments as String;
 

--- a/lib/clipboard_monitor.dart
+++ b/lib/clipboard_monitor.dart
@@ -1,40 +1,47 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/services.dart';
 
 // typedef OnClipboardTextFunction = void Function(String text);
 
 class ClipboardMonitor {
-  static const MethodChannel _channel =
-      const MethodChannel('clipboard_monitor');
+  static const MethodChannel _channel = const MethodChannel('clipboard_monitor');
 
-  static bool _initialized = false;
+  static var _monitoring = false;
 
   static final _callbacks = List<Function(String)>();
 
-  static void _init() async {
-    if (_initialized) return;
+  static Future<void> _startMonitoring() async {
+    _monitoring = true;
     _channel.setMethodCallHandler(_handleMethodCall);
-    _initialized = true;
-
     await _channel.invokeMethod('monitorClipboard');
   }
 
+  static Future<void> _stopMonitoring() async {
+    _monitoring = false;
+    await _channel.invokeMethod('stopMonitoringClipboard');
+  }
+
   static void registerCallback(Function(String) func) {
-    if (!_initialized) {
-      _init();
+    if (!_monitoring) {
+      _startMonitoring();
     }
     _callbacks.add(func);
   }
 
   static void unregisterCallback(Function(String) func) {
     _callbacks.remove(func);
+
+    if (Platform.isAndroid && _callbacks.isEmpty) {
+      // remove the listener since there are no callbacks registered.
+      // nb: Not implemented on iOS yet so this will only affect android
+      _stopMonitoring();
+    }
   }
 
   static Future<void> _handleMethodCall(MethodCall call) async {
-    // print('_handleMethodCall: ' + call.method);
-    // print(call.arguments);
-    var args = call.arguments as String;
+    final args = call.arguments as String;
 
     if (call.method == 'cliptext') {
       _callbacks.forEach((cb) => cb(args));


### PR DESCRIPTION
These are a series of changes where I refactored the android implementation to idiomatic kotlin and added functionality to stopMonitoring the clipboard on Android when there are no more callbacks registered. I also refactored the dart side and added a method to unregister all callbacks.